### PR TITLE
Fix new style Cortana URIs

### DIFF
--- a/EdgeDeflector/EdgeDeflector.csproj
+++ b/EdgeDeflector/EdgeDeflector.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/EdgeDeflector/Program.cs
+++ b/EdgeDeflector/Program.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Win32;
 using System;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Security.Principal;
 using System.Text.RegularExpressions;
+using System.Web;
 
 namespace EdgeDeflector
 {
@@ -108,6 +110,18 @@ namespace EdgeDeflector
             return uri.StartsWith("microsoft-edge:", StringComparison.OrdinalIgnoreCase) && !uri.Contains(" ");
         }
 
+        static string GetURIFromCortanaLink(string uri)
+        {
+            NameValueCollection queryCollection = HttpUtility.ParseQueryString(uri);
+            return HttpUtility.UrlDecode(queryCollection["url"]);
+        }
+
+        static string EncodeCortanaParameters(string cortanaUri)
+        {
+            Uri uri = new Uri(cortanaUri);
+            return uri.AbsoluteUri + "?" + HttpUtility.UrlEncode(uri.Query);
+        }
+
         static string RewriteMsEdgeUriSchema(string uri)
         {
             string msedge_protocol_pattern = "^microsoft-edge:/*";
@@ -118,6 +132,14 @@ namespace EdgeDeflector
             if (IsHttpUri(new_uri))
             {
                 return new_uri;
+            }
+
+            // May be new-style Cortana URI - try and split out
+            string cortanaUri = GetURIFromCortanaLink(uri);
+            if (IsHttpUri(cortanaUri))
+            {
+                // Correctly form the new URI before returning
+                return EncodeCortanaParameters(cortanaUri);
             }
 
             return "http://" + new_uri;

--- a/EdgeDeflector/Program.cs
+++ b/EdgeDeflector/Program.cs
@@ -110,6 +110,11 @@ namespace EdgeDeflector
             return uri.StartsWith("microsoft-edge:", StringComparison.OrdinalIgnoreCase) && !uri.Contains(" ");
         }
 
+        static bool IsNewCortanaURI(string uri)
+        {
+            return (uri.Contains("launchContext1=Microsoft.Windows.Cortana"));
+        }
+
         static string GetURIFromCortanaLink(string uri)
         {
             NameValueCollection queryCollection = HttpUtility.ParseQueryString(uri);
@@ -135,11 +140,14 @@ namespace EdgeDeflector
             }
 
             // May be new-style Cortana URI - try and split out
-            string cortanaUri = GetURIFromCortanaLink(uri);
-            if (IsHttpUri(cortanaUri))
+            if (IsNewCortanaURI(uri))
             {
-                // Correctly form the new URI before returning
-                return EncodeCortanaParameters(cortanaUri);
+                string cortanaUri = GetURIFromCortanaLink(uri);
+                if (IsHttpUri(cortanaUri))
+                {
+                    // Correctly form the new URI before returning
+                    return EncodeCortanaParameters(cortanaUri);
+                }
             }
 
             return "http://" + new_uri;


### PR DESCRIPTION
Ref issue #14 I have created this fix for new Cortana type URIs.

It seems the format is now as such (searched for "testing t"):
`microsoft-edge:?launchContext1=Microsoft.Windows.Cortana_cw5n1h2txyewy&url=https%3A%2F%2Fwww.bing.com%2Fsearch%3Fq%3Dtesting%2Bt%26form%3DWNSGPH%26qs%3DSW%26cvid%3D6411b7b380b4455797ac68274c17ef46%26pq%3Dtesting%2Bt%26cc%3DGB%26setlang%3Den-GB%26nclid%3D274810CCC78079B0E973EEA2608FE604%26ts%3D1501325007915%26nclidts%3D1501325007%26tsms%3D915%26elv%3DAXK1c4IvZoNqPoPnS%2521QRLON9Hzh90kZPFAp3rV%2521GhN3UD%25218j5lR9zmW6jlP3HjlD4v%2521ifJ4GuPDthdz1ohXCiGLz%2521z5%2521OG3PF9JiL8%2AGGtkG`

My fix will check for this type of Cortana URI and extract the required sections.