### PR TITLE
Fix for reference path issue 114

### DIFF
--- a/EdgeDeflector/resources/nsis_installer.nsi
+++ b/EdgeDeflector/resources/nsis_installer.nsi
@@ -57,12 +57,12 @@ Section "Installer"
   ; Register protocol
   WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}.microsoft-edge" "" "URL: MICROSOFT-EDGE"
   WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}.microsoft-edge" "URL Protocol" ""
-  WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}.microsoft-edge\shell\open\command" "" "$INSTDIR\${PRODUCT}.exe %1"
+  WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}.microsoft-edge\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
 
   ; Program class registration
   WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}\Application" "ApplicationName" "${PRODUCT}"
   WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}\DefaultIcon" "" "$INSTDIR\${PRODUCT}.exe,0"
-  WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}\shell\open\command" "" "$INSTDIR\${PRODUCT}.exe %1"
+  WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}\shell\open\command" "" '"$INSTDIR\${PRODUCT}.exe" "%1"'
   WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}\Capabilities" "ApplicationName" "${PRODUCT}"
   WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}\Capabilities" "ApplicationIcon" "$INSTDIR\${PRODUCT}.exe,0"
   WriteRegStr HKCU "SOFTWARE\Classes\${PRODUCT}\Capabilities" "ApplicationDescription" "${DESCRIPTION}"


### PR DESCRIPTION
- This will fix https://github.com/da2x/EdgeDeflector/issues/114#issuecomment-907209577
- **_tl;dr_** windows misreading the application path if the user install-directory has space in between their usernames like this...
- C:\Users\\**John**\AppData\Local\Programs\EdgeDeflector have no problems with application.
-    C:\Users\\**John Cena**\AppData\Local\Programs\EdgeDeflector are facing [this issue](https://github.com/da2x/EdgeDeflector/issues/114).